### PR TITLE
updated the pull request template to simplify legal stuff and remove …

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,9 +10,11 @@ Add any other context
 
 - [ ] Documentation is added
 - [ ] Test cases are added or updated
-- [ ] I've read the contributing document https://github.com/cherrytwist/.github/blob/master/CONTRIBUTING.md
-- [ ] I've read and understand the Code of Conduct https://github.com/cherrytwist/.github/blob/master/CODE_OF_CONDUCT.md
-- [ ] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
-     https://github.com/cherrytwist/Coordination/blob/master/LICENSE 
-     and the contributor license agreement: tba
+
+By submitting this pull request I confirm that:
+- I've read the contributing document https://github.com/cherrytwist/.github/blob/master/CONTRIBUTING.md.
+- I've read and understand the Code of Conduct https://github.com/cherrytwist/.github/blob/master/CODE_OF_CONDUCT.md.
+- I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
+     https://github.com/cherrytwist/Coordination/blob/master/LICENSE.
+- I understand that submitting the pull request requires agreeing to and signing the contributor license agreement.
  


### PR DESCRIPTION
…redundant declarations on CLA

### Describe the background of your pull request
The current pull request template requires submitters to declare they agree the the conditions for contributing code by filling in tock boxes. This is cumbersome, often not done and not enforced. It is also redundant with the requirement to sign the CLA. This update simplifies the pull request template

What does your pull request do? Does it solve a bug (which one?), add a feature?

### Additional context

Add any other context

### Governance 

- [ ] Documentation is added
- [ ] Test cases are added or updated
- [x] I've read the contributing document https://github.com/cherrytwist/.github/blob/master/CONTRIBUTING.md
- [x] I've read and understand the Code of Conduct https://github.com/cherrytwist/.github/blob/master/CODE_OF_CONDUCT.md
- [x] I understand that any contributions or suggestions I made may make it into the actual code. I've read the License 
     https://github.com/cherrytwist/Coordination/blob/master/LICENSE 
     and the contributor license agreement: tba
 
